### PR TITLE
fix: Switch color switcher to have fixed position

### DIFF
--- a/src/app/color-switcher/color-switcher.component.css
+++ b/src/app/color-switcher/color-switcher.component.css
@@ -1,6 +1,6 @@
 #switcher-container {
-  position: absolute;
-  bottom: 30px;
+  position: fixed;
+  bottom: 20px;
   left: 20px;
 }
 


### PR DESCRIPTION
Switched position from `absolute` to `fixed`. Now moves with scrollbar.