### PR TITLE
Remove portfolio refresh on resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.5.4](https://github.com/strigiforme/portfolio/compare/v0.5.3...v0.5.4) (2022-11-18)
+
+
+### Bug Fixes
+
+* Remove website refresh on resize ([fd60cb2](https://github.com/strigiforme/portfolio/commit/fd60cb2e018be1cb697acf0dc3dec90233d688f5))
+
 ### [0.5.3](https://github.com/strigiforme/portfolio/compare/v0.5.2...v0.5.3) (2022-11-15)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portfolio",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "portfolio",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "@angular/animations": "~13.3.0",
         "@angular/common": "~13.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/assets/js/HeroAnimation.js
+++ b/src/assets/js/HeroAnimation.js
@@ -1,7 +1,10 @@
+// variables that need global context for interacting with other parts of the website
 var currentColorIsDark = false;
 var currentColorIsLight = false;
-
 let grid;
+let renderer;
+let camera;
+let canvas;
 
 // constants
 const CIRCLE_SPEED = 0.1;
@@ -9,9 +12,15 @@ const DRIFT_SPEED = 0.05;
 const GUARD = 0.05;
 const SCENE_WIDTH = 14;
 const SCENE_HEIGHT = 16;
-
 const LIGHT_COLOR = 0xD9D9D9;
 const DARK_COLOR = 0x1E1E1E;
+
+window.addEventListener( 'resize', onWindowResize, false );
+function onWindowResize(){
+  camera.aspect = canvas.clientWidth / canvas.clientHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize( canvas.clientWidth, canvas.clientHeight );
+}
 
 class DotGrid {
   constructor(screenWidth, sceneWidth, sceneHeight, screenHeight, particleSeparation, bufferGeometry) {
@@ -114,10 +123,9 @@ class DotGrid {
 
 var animation = function () {
   // container for animation
-  const canvas = document.querySelector("#hero-graphic");
+  canvas = document.querySelector("#hero-graphic");
   var width = canvas.clientWidth;
   var height = canvas.clientHeight;
-
 
   var waveCenterX = 0;
   var waveCenterY = 0;
@@ -133,20 +141,16 @@ var animation = function () {
   grid.initializePosition();
   grid.initializeColor(LIGHT_COLOR);
 
-  // console.log(grid);
-  // console.log("Particles per row: " + grid.particlesPerRow);
-  // console.log("Number of rows required: " + grid.numberOfRowsRequired);
-
   // set up scene
-  const scene = new THREE.Scene();
-  const camera = new THREE.PerspectiveCamera(115, width / height, 1, 20 );
-  const renderer = new THREE.WebGLRenderer( { alpha: true } );
+  var scene = new THREE.Scene();
+  camera = new THREE.PerspectiveCamera(115, width / height, 1, 20 );
+  renderer = new THREE.WebGLRenderer( { alpha: true } );
 
   renderer.setClearColor(0x000000, 0);
   renderer.setSize(width, height);
   canvas.appendChild(renderer.domElement);
 
-  const material = new THREE.PointsMaterial( { size: 0.01, vertexColors: true } );
+  var material = new THREE.PointsMaterial( { size: 0.01, vertexColors: true } );
   bufferGeometry.dynamic = true;
   var particlesMesh = new THREE.Points(bufferGeometry, material);
   scene.add(particlesMesh);
@@ -168,6 +172,8 @@ var animation = function () {
     light1.position.z = 0;
     scene.add(light1);
   }
+
+
 
   function distanceFromCenter(x, y) {
     return Math.sqrt(Math.pow(x - waveCenterX, 2) + Math.pow(y - waveCenterY, 2));
@@ -232,6 +238,7 @@ var animation = function () {
 
     bufferGeometry.attributes.position.needsUpdate = true;
     bufferGeometry.attributes.color.needsUpdate = true;
+
   }
 
 }

--- a/src/index.html
+++ b/src/index.html
@@ -8,10 +8,6 @@
   <!-- RE-ADD WHEN I HAVE AN ACTUAL ICON  <link rel="icon" type="image/x-icon" href="favicon.ico"> -->
   <script src="https://kit.fontawesome.com/4305f7f018.js" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/0.144.0/three.min.js"></script>
-  <script>
-    // Dot animation acts weird if you resize the window. Refreshing fixes it.
-    window.onresize = function(event) { document.location.reload(true); }
-  </script>
   <script src="./assets/js/HeroAnimation.js"></script>
   <script src="./assets/js/ChangeColors.js"></script>
   <script src="./assets/js/Utils.js"></script>

--- a/src/styles.css
+++ b/src/styles.css
@@ -25,7 +25,7 @@
 
 /* allows for color switching to look good */
 * {
-  transition: all 1s ease-in;
+  transition: color 1s ease-in, background-color 1s ease-in;
 }
 
 /* Structure styles used in every section */


### PR DESCRIPTION
Instead of refreshing the portfolio when the browser resize event occurs, change the aspect ratio and width/height of the hero animation (this was the original intent of the refresh event anyway).

This prevents incredibly buggy phone behavior.