### PR TITLE
fix: Fix alignment on experience scroller by making font smaller

### DIFF
--- a/src/app/structural-components/experience-section/experience-section.component.css
+++ b/src/app/structural-components/experience-section/experience-section.component.css
@@ -15,10 +15,10 @@
 }
 
 .experience span {
-  font-size: 32px;
+  font-size: 40px;
   font-family: 'Bebas Neue';
   color: var(--primary-color);
-  padding-right: 25px;
+  padding-right: 10px;
   font-weight: bold;
   transition: none;
 }
@@ -132,7 +132,7 @@ i {
     margin-top: 5px;
   }
   .experience span {
-    font-size: 36px;
+    font-size: 30px;
     padding-right: 10px;
   }
   .experience p {


### PR DESCRIPTION
Make the experience switcher font smaller to improve alignment. Also improve some small alignment issues.